### PR TITLE
Remove unnecessary constructors from commands

### DIFF
--- a/src/Commands/DownloadTranslations.php
+++ b/src/Commands/DownloadTranslations.php
@@ -24,16 +24,6 @@ class DownloadTranslations extends Command
     protected $description = 'Download current translations in all languages from Loco';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @param ApiClient $client

--- a/src/Commands/UploadTranslations.php
+++ b/src/Commands/UploadTranslations.php
@@ -24,16 +24,6 @@ class UploadTranslations extends Command
     protected $description = 'Export current English translations to the Loco TMS';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @param ApiClient $client


### PR DESCRIPTION
This PR removes constructors that only have a `parent::__construct()` call. We can just let it fall through automagically.