### PR TITLE
deps: use official loco sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "illuminate/filesystem": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/translation": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "loco/loco": "^1.0|^2.0|2.0.x-dev"
+        "loco/loco": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0"
@@ -36,11 +36,5 @@
                 "Jobilla\\Loco\\LocoServiceProvider"
             ]
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:andvla/loco.git"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
[Official loco sdk](https://github.com/loco/loco-php-sdk) is being installed while installing the laravel-loco-tms package and not the forked package. Also, [forked version](https://github.com/andvla/loco) is not maintained. Last commit was 3 years ago. 