### PR TITLE
Additional params for import and export endpoint

### DIFF
--- a/config/loco.php
+++ b/config/loco.php
@@ -2,4 +2,17 @@
 
 return [
     'api_key' => env('LOCO_API_KEY'),
+
+    /**
+     * Additional params to use for the export endpoint
+     * https://localise.biz/api/docs/export/exportall
+     */
+    'export_params' => [],
+
+    /**
+     * Additional params to use for the import endpoint
+     * https://localise.biz/api/docs/import/import
+     *
+     */
+    'import_params' => [],
 ];

--- a/readme.md
+++ b/readme.md
@@ -18,3 +18,13 @@ To publish the configuration file, run:
 ```sh
 php artisan vendor:publish --provider="Jobilla\Loco\LocoServiceProvider"
 ```
+
+There are two different endpoints used for import and export. It is possible to set different parameters on those endpoints. Parameters for export endpoint can be found [here](https://localise.biz/api/docs/export/exportall). Parameters for import endpoint can be found [here](https://localise.biz/api/docs/import/import). Those paramters can be set in configuration file of the package.
+
+For example, this is how order parameter can be set in configuration file:
+
+```php
+'export_params' => [
+        'order' => 'id',
+    ],
+```

--- a/src/Commands/DownloadTranslations.php
+++ b/src/Commands/DownloadTranslations.php
@@ -32,9 +32,10 @@ class DownloadTranslations extends Command
      */
     public function handle(ApiClient $client, Translator $translator, FilesystemManager $storage)
     {
-        $res = $client->exportAll([
-            'ext' => 'json',
-        ]);
+        $res = $client->exportAll(array_merge(
+            config('loco.export_params', []),
+            ['ext' => 'json']
+        ));
 
         $translations = $this->dropEmptyString(json_decode((string)$res, JSON_OBJECT_AS_ARRAY));
         $fs = $storage->createLocalDriver(['root' => resource_path('lang')]);

--- a/src/Commands/UploadTranslations.php
+++ b/src/Commands/UploadTranslations.php
@@ -44,11 +44,11 @@ class UploadTranslations extends Command
 
             $this->info("Sending $locale translations to Loco...");
             $locale = str_replace('_', '-', $locale);
-            $res = $client->import([
+            $res = $client->import(array_merge(config('loco.import_params', []), [
                 'locale' => $locale,
                 'ext' => 'json',
                 'data' => json_encode($translations)
-            ]);
+            ]));
             $this->info("✔ $locale upload complete: {$res['message']}");
         }
 


### PR DESCRIPTION
This allows setting extra parameters on [import](https://localise.biz/api/docs/import/import) or [export](https://localise.biz/api/docs/export/exportall) endpoint.
For example to set ignore-existing=true to not overwrite values in loco.